### PR TITLE
Update v1.1.1

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,7 +3,7 @@ name: .NET Core Build and Test
 on:
   pull_request:
     branches:
-    - master
+    - main
     paths:
     - '**.cs'
     - '**.csproj'
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 5.0.x
     - name: Add GitHub Packages for Nuget
       run: dotnet nuget add source https://nuget.pkg.github.com/bassclefstudio/index.json --name "GPR" --username bassclefstudio --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text
     - name: Install dependencies

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,7 +3,7 @@ name: .NET Core Build, Test, and Pack
 on:
   push:
     branches:
-    - master
+    - main
     paths:
         - '**.csproj'
   workflow_dispatch:
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 5.0.x
     - name: Add GitHub Packages to Nuget
       run: dotnet nuget add source https://nuget.pkg.github.com/bassclefstudio/index.json --name "GPR" --username bassclefstudio --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text
     - name: Install dependencies
@@ -28,4 +28,4 @@ jobs:
     - name: Pack
       run: dotnet pack --no-build
     - name: Push
-      run: dotnet nuget push "**.nupkg" --source "GPR" --skip-duplicate --no-symbols true
+      run: dotnet nuget push "**.nupkg" --source "GPR" --skip-duplicate --no-symbols true -k ${{ secrets.GITHUB_TOKEN }}

--- a/BassClefStudio.Serialization/BassClefStudio.Serialization.csproj
+++ b/BassClefStudio.Serialization/BassClefStudio.Serialization.csproj
@@ -5,7 +5,7 @@
     <Authors>BassClefStudio</Authors>
     <Description>Supports dynamic serialization to and from XML, JSON, and other data structures without having to build often-complex data models just for serialization, using DI with Autofac to build data models.</Description>
     <RepositoryUrl>https://github.com/bassclefstudio/.NET-Serialization.git</RepositoryUrl>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.NET-Serialization</PackageProjectUrl>
   </PropertyGroup>
 

--- a/BassClefStudio.Serialization/DI/ConverterService.cs
+++ b/BassClefStudio.Serialization/DI/ConverterService.cs
@@ -30,9 +30,16 @@ namespace BassClefStudio.Serialization.DI
                 var builder = new ContainerBuilder();
                 ConverterModule converterModule = new ConverterModule(assemblies);
                 builder.RegisterModule(converterModule);
+                ConfigureServices(builder);
                 ConverterContainer = builder.Build();
             }
         }
+
+        /// <summary>
+        /// Configures any services that are not simply closed types of <see cref="IConverter{TFrom, TTo}"/> or known <see cref="IKeyManager{TItem, TStore}"/>s to the converter DI container.
+        /// </summary>
+        /// <param name="builder">The Autofac <see cref="ContainerBuilder"/>.</param>
+        protected virtual void ConfigureServices(ContainerBuilder builder) { }
 
         /// <summary>
         /// Serializes the <see cref="TItem"/> into a <see cref="TOutput"/>.


### PR DESCRIPTION
Allows for DI containers in `ConverterService`s to be configured manually using
````C#
virtual void ConfigureServices(ContainerBuilder builder)
````
which is now included. This push is also the rename from the `master` to `main` branch in this repo. No functionality has changed with this PR.