### PR TITLE
v2.1 - Constructor improvements, customization options, value type fixes

### DIFF
--- a/BassClefStudio.NET.Serialization.Tests/SerializerTests.cs
+++ b/BassClefStudio.NET.Serialization.Tests/SerializerTests.cs
@@ -2,6 +2,7 @@ using BassClefStudio.NET.Serialization.Graphs;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Reflection;
 
 namespace BassClefStudio.NET.Serialization.Tests
@@ -30,7 +31,7 @@ namespace BassClefStudio.NET.Serialization.Tests
         {
             Derived d = new Derived();
 
-            var serializer = new SerializationService(typeof(SerializerTests).Assembly);
+            var serializer = new SerializationService(typeof(Base));
             Assert.ThrowsException<GraphTypeException>(() => serializer.Serialize(d));
         }
 
@@ -48,7 +49,7 @@ namespace BassClefStudio.NET.Serialization.Tests
         {
             string json = $"[{{\"$type\":\"node\", \"Link\":{{\"Id\":0}}, \"TypeName\":\"{typeof(BadDerived).AssemblyQualifiedName}\", \"Properties\":{{}}}}]";
 
-            var serializer = new SerializationService(typeof(SerializerTests).Assembly);
+            var serializer = new SerializationService(typeof(Base));
             Assert.ThrowsException<GraphTypeException>(() => serializer.Deserialize<Base>(json));
         }
 
@@ -71,6 +72,47 @@ namespace BassClefStudio.NET.Serialization.Tests
             Assert.AreEqual(4, listE.Parents.Count);
             Assert.AreEqual(listE.Child, listE.Parents[0]);
         }
+
+        [TestMethod]
+        public void TestNoConstructor()
+        {
+            Base a = new Base();
+            DerivedNoConst b = new DerivedNoConst(a, "Fred");
+            a.Child = b;
+
+            var serializer = new SerializationService(typeof(SerializerTests).Assembly);
+            string json = serializer.Serialize(a);
+            Console.WriteLine(json);
+            Base newA = serializer.Deserialize<Base>(json);
+            Assert.AreEqual(newA.Child.Child, newA);
+            Assert.IsInstanceOfType(newA.Child, typeof(Derived));
+            Assert.AreEqual(((Derived)newA.Child).Name, "Fred");
+        }
+
+        [TestMethod]
+        public void ExplicitValueSerialize()
+        {
+            Vector2 vector = new Vector2(10, 40);
+            var serializer = new SerializationService(GraphBehaviour.IncludeFields | GraphBehaviour.SetFields, typeof(Vector2));
+            string json = serializer.Serialize(vector);
+            Console.WriteLine(json);
+            Vector2 newVector = serializer.Deserialize<Vector2>(json);
+            Assert.AreEqual(vector, newVector);
+        }
+
+        [TestMethod]
+        public void CustomSerializer()
+        {
+            GuidDerived a = new GuidDerived() { Child = null, Id = Guid.NewGuid() };
+            Base b = new Base() { Child = a };
+            var serializer = new SerializationService(new Assembly[] { typeof(SerializerTests).Assembly }, new Type[] { typeof(Guid) });
+            serializer.AddCustomSerializer(new GuidSerializer());
+            string json = serializer.Serialize(b);
+            Console.WriteLine(json);
+            Base newB = serializer.Deserialize<Base>(json);
+            Assert.IsInstanceOfType(newB.Child, typeof(GuidDerived));
+            Assert.AreEqual(a.Id, ((GuidDerived)newB.Child).Id);
+        }
     }
 
     public class Base
@@ -81,6 +123,20 @@ namespace BassClefStudio.NET.Serialization.Tests
     public class Derived : Base
     {
         public string Name { get; set; }
+    }
+
+    public class GuidDerived : Base
+    {
+        public Guid Id { get; set; }
+    }
+
+    public class DerivedNoConst : Derived
+    {
+        public DerivedNoConst(Base child, string name)
+        {
+            Child = child;
+            Name = name;
+        }
     }
 
     public class BadDerived : Base
@@ -94,5 +150,20 @@ namespace BassClefStudio.NET.Serialization.Tests
     public class ListDerived : Base
     {
         public List<Base> Parents { get; set; }
+    }
+
+    public class GuidSerializer : ICustomSerializer
+    {
+        public TypeGroup ApplicableTypes { get; } = new TypeGroup(typeof(Guid));
+        
+        public object Deserialize(string value)
+        {
+            return Guid.Parse(value);
+        }
+
+        public string Serialize(object o)
+        {
+            return ((Guid)o).ToString("N");
+        }
     }
 }

--- a/BassClefStudio.NET.Serialization.Tests/SerializerTests.cs
+++ b/BassClefStudio.NET.Serialization.Tests/SerializerTests.cs
@@ -30,7 +30,7 @@ namespace BassClefStudio.NET.Serialization.Tests
         {
             Derived d = new Derived();
 
-            var serializer = new SerializationService(typeof(Base));
+            var serializer = new SerializationService(typeof(SerializerTests).Assembly);
             Assert.ThrowsException<GraphTypeException>(() => serializer.Serialize(d));
         }
 
@@ -39,7 +39,7 @@ namespace BassClefStudio.NET.Serialization.Tests
         {
             string json = $"[{{\"$type\":\"node\", \"Link\":{{\"Id\":0}}, \"TypeName\":\"{typeof(System.IO.File).AssemblyQualifiedName}\", \"Properties\":{{}}}}]";
 
-            var serializer = new SerializationService(typeof(Base));
+            var serializer = new SerializationService(typeof(SerializerTests).Assembly);
             Assert.ThrowsException<GraphTypeException>(() => serializer.Deserialize<Base>(json));
         }
 
@@ -48,7 +48,7 @@ namespace BassClefStudio.NET.Serialization.Tests
         {
             string json = $"[{{\"$type\":\"node\", \"Link\":{{\"Id\":0}}, \"TypeName\":\"{typeof(BadDerived).AssemblyQualifiedName}\", \"Properties\":{{}}}}]";
 
-            var serializer = new SerializationService(typeof(Base));
+            var serializer = new SerializationService(typeof(SerializerTests).Assembly);
             Assert.ThrowsException<GraphTypeException>(() => serializer.Deserialize<Base>(json));
         }
 
@@ -61,7 +61,7 @@ namespace BassClefStudio.NET.Serialization.Tests
             Base d = new Base();
             ListDerived e = new ListDerived() { Child = a, Parents = new List<Base>() { a, b, c, d } };
 
-            var serializer = new SerializationService(new Assembly[] { typeof(SerializerTests).Assembly }, new Type[] { typeof(List<>) });
+            var serializer = new SerializationService(typeof(SerializerTests).Assembly);
             string json = serializer.Serialize(e);
             Console.WriteLine(json);
             Base newE = serializer.Deserialize<Base>(json);

--- a/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
+++ b/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
@@ -5,7 +5,7 @@
     <Authors>BassClefStudio</Authors>
     <Description>A new serialization engine that provides serialization and deserialization services for complex graphs of objects, preserving references and allowing for polymorphism of trusted types, while using JSON as the output format.</Description>
     <RepositoryUrl>https://github.com/bassclefstudio/.NET-Serialization.git</RepositoryUrl>
-    <Version>2.0.1</Version>
+    <Version>2.1.0</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.NET-Serialization</PackageProjectUrl>
     <PackageId>BassClefStudio.NET.Serialization</PackageId>
     <Product>BassClefStudio.NET.Serialization</Product>

--- a/BassClefStudio.NET.Serialization/Graphs/CollectionNode.cs
+++ b/BassClefStudio.NET.Serialization/Graphs/CollectionNode.cs
@@ -17,7 +17,7 @@ namespace BassClefStudio.NET.Serialization.Graphs
         public List<NodeLink> Children { get; }
 
         /// <summary>
-        /// Creates a new <see cref="Node"/>.
+        /// Creates a new <see cref="CollectionNode"/>.
         /// </summary>
         /// <param name="myLink">The <see cref="NodeLink"/> that can be used for referring to this <see cref="Node"/> instance.</param>
         /// <param name="basedOn">The <see cref="object"/> that this <see cref="Node"/> represents.</param>

--- a/BassClefStudio.NET.Serialization/Graphs/CustomValueNode.cs
+++ b/BassClefStudio.NET.Serialization/Graphs/CustomValueNode.cs
@@ -1,0 +1,30 @@
+﻿using JsonKnownTypes;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.NET.Serialization.Graphs
+{
+    /// <summary>
+    /// Represents a <see cref="Node"/> for a given <see cref="object"/> that has a custom-generated <see cref="string"/> serialization built for it. Note that <see cref="CustomValueNode"/> does not support native <see cref="Graph"/> features such as reference handling.
+    /// </summary>
+    [JsonKnownThisType("custom")]
+    public class CustomValueNode : Node
+    {
+        /// <summary>
+        /// The value of this <see cref="CustomValueNode"/>'s object, as its <see cref="string"/> representation.
+        /// </summary>
+        [JsonProperty("Value")]
+        public string ValueString { get; set; }
+
+        /// <summary>
+        /// Creates a new <see cref="CustomValueNode"/>.
+        /// </summary>
+        /// <param name="myLink">The <see cref="NodeLink"/> that can be used for referring to this <see cref="Node"/> instance.</param>
+        /// <param name="basedOn">The <see cref="object"/> that this <see cref="Node"/> represents.</param>
+        public CustomValueNode(NodeLink myLink, object basedOn) : base(myLink, basedOn)
+        {
+        }
+    }
+}

--- a/BassClefStudio.NET.Serialization/Graphs/Graph.cs
+++ b/BassClefStudio.NET.Serialization/Graphs/Graph.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -36,7 +37,8 @@ namespace BassClefStudio.NET.Serialization.Graphs
         /// </summary>
         public static Type[] DefaultTrustedTypes { get; } = new Type[]
         {
-            typeof(List<>)
+            typeof(List<>),
+            typeof(ObservableCollection<>)
         };
 
         private int Index = 0;
@@ -175,36 +177,13 @@ namespace BassClefStudio.NET.Serialization.Graphs
             foreach (var node in Nodes)
             {
                 var nodeType = GetTrustedType(node.TypeName);
-                var nodeConsts = nodeType.GetConstructors();
-                if (node is CollectionNode collectionNode)
+                if (node is CollectionNode)
                 {
-                    //// Collection constructor
-                    ConstructorInfo parameterless = nodeConsts.FirstOrDefault(c => !c.GetParameters().Any());
-                    if (parameterless != null)
-                    {
-                        var myObject = parameterless.Invoke(new object[0]);
-                        node.BasedOn = myObject;
-                        nodeBuilders.Add(node.MyLink, node);
-                    }
-                    else
-                    {
-                        throw new GraphException($"Currently cannot create an instance of an object without a parameterless constructor. Type: {nodeType.FullName}.");
-                    }
+                    node.BasedOn = FormatterServices.GetUninitializedObject(nodeType);
                 }
                 else
                 {
-                    //// Object constructor
-                    ConstructorInfo parameterless = nodeConsts.FirstOrDefault(c => !c.GetParameters().Any());
-                    if (parameterless != null)
-                    {
-                        var myObject = parameterless.Invoke(new object[0]);
-                        node.BasedOn = myObject;
-                        nodeBuilders.Add(node.MyLink, node);
-                    }
-                    else
-                    { 
-                        throw new GraphException($"Currently cannot create an instance of an object without a parameterless constructor. Type: {nodeType.FullName}.");
-                    }
+                    node.BasedOn = FormatterServices.GetUninitializedObject(nodeType);
                 }
             }
             //// Now we have a Dictionary with Node objects (and their constructed .NET objects), we can set all properties on the objects.

--- a/BassClefStudio.NET.Serialization/Graphs/GraphBehavior.cs
+++ b/BassClefStudio.NET.Serialization/Graphs/GraphBehavior.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BassClefStudio.NET.Serialization.Graphs
+{
+    /// <summary>
+    /// Contains information about how the <see cref="Graph"/> should build and read <see cref="object"/>s.
+    /// </summary>
+    public class GraphBehaviourInfo
+    {
+        /// <summary>
+        /// The <see cref="TypeGroup"/> defining all applicable object <see cref="Type"/>s.
+        /// </summary>
+        public TypeGroup ApplicableTypes { get; }
+
+        /// <summary>
+        /// <see cref="GraphBehaviour"/> flags indicating the desired changes in serialiaztion/deserialization behaviour.
+        /// </summary>
+        public GraphBehaviour Behaviours { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="GraphBehaviourInfo"/> definition.
+        /// </summary>
+        /// <param name="types">The <see cref="TypeGroup"/> defining all applicable object <see cref="Type"/>s.</param>
+        /// <param name="behaviours"><see cref="GraphBehaviour"/> flags indicating the desired changes in serialiaztion/deserialization behaviour.</param>
+        public GraphBehaviourInfo(TypeGroup types, GraphBehaviour behaviours)
+        {
+            ApplicableTypes = types;
+            Behaviours = behaviours;
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="Enum"/> with flags defining behaviours the <see cref="Graph"/> can have when managing certain <see cref="object"/>s.
+    /// </summary>
+    [Flags]
+    public enum GraphBehaviour
+    { 
+        /// <summary>
+        /// No behaviors have been implemented.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Serialize all public fields and properties (usual: just public properties).
+        /// </summary>
+        IncludeFields = 1 << 0,
+
+        /// <summary>
+        /// When deserializing, attempt to set field values as well as property values.
+        /// </summary>
+        SetFields = 1 << 1,
+
+        /// <summary>
+        /// Additionally serialize properties (or fields, if set) that are read-only.
+        /// </summary>
+        ReadOnly = 1 << 2,
+
+        /// <summary>
+        /// Attempts to create objects in deserialization of known types using non-default constructors (parameters resolved by name and type).
+        /// </summary>
+        ParameterConstructor = 1 << 3
+    }
+
+    /// <summary>
+    /// Extension methods for the <see cref="GraphBehaviourInfo"/> class.
+    /// </summary>
+    public static class GraphBehaviorExtensions
+    {
+        /// <summary>
+        /// Gets the collection of <see cref="GraphBehaviour"/>s that are applicable to the current <see cref="Type"/> from a collection of <see cref="GraphBehaviourInfo"/>s.
+        /// </summary>
+        /// <param name="behaviours">The collection of <see cref="GraphBehaviourInfo"/>s.</param>
+        /// <param name="type">The desired <see cref="Type"/>.</param>
+        /// <returns>A <see cref="GraphBehaviour"/> enum with all applicable flags set.</returns>
+        public static GraphBehaviour GetBehaviours(this IEnumerable<GraphBehaviourInfo> behaviours, Type type)
+        {
+            var allFlags = behaviours.Where(b => b.ApplicableTypes.IsMember(type)).Select(b => b.Behaviours);
+            GraphBehaviour flags = GraphBehaviour.None;
+            foreach (var f in allFlags)
+            {
+                flags |= f;
+            }
+            return flags;
+        }
+    }
+}

--- a/BassClefStudio.NET.Serialization/Graphs/NodeLink.cs
+++ b/BassClefStudio.NET.Serialization/Graphs/NodeLink.cs
@@ -35,5 +35,11 @@ namespace BassClefStudio.NET.Serialization.Graphs
         {
             return new NodeLink(id);
         }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return Id.ToString();
+        }
     }
 }

--- a/BassClefStudio.NET.Serialization/Graphs/TypeGroup.cs
+++ b/BassClefStudio.NET.Serialization/Graphs/TypeGroup.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace BassClefStudio.NET.Serialization.Graphs
+{
+    /// <summary>
+    /// Represents a group of <see cref="Assembly"/> and <see cref="Type"/> instances that represent a group of object types.
+    /// </summary>
+    public class TypeGroup
+    {
+        /// <summary>
+        /// A collection of known <see cref="Assembly"/> references (all types in the assembly are members of the <see cref="TypeGroup"/>).
+        /// </summary>
+        public List<Assembly> KnownAssemblies { get; }
+
+        /// <summary>
+        /// A collection of known <see cref="Type"/> references (all types are members of the <see cref="TypeGroup"/>).
+        /// </summary>
+        public List<Type> KnownTypes { get; }
+
+        /// <summary>
+        /// Creates a new empty <see cref="TypeGroup"/>.
+        /// </summary>
+        public TypeGroup()
+        {
+            KnownAssemblies = new List<Assembly>();
+            KnownTypes = new List<Type>();
+        }
+
+        /// <summary>
+        /// Creates a new empty <see cref="TypeGroup"/>.
+        /// </summary>
+        /// <param name="knownAssemblies">A collection of known <see cref="Assembly"/> references.</param>
+        public TypeGroup(params Assembly[] knownAssemblies) : this()
+        {
+            KnownAssemblies.AddRange(knownAssemblies);
+        }
+
+        /// <summary>
+        /// Creates a new empty <see cref="TypeGroup"/>.
+        /// </summary>
+        /// <param name="knownTypes">A collection of known <see cref="Type"/> references.</param>
+        public TypeGroup(params Type[] knownTypes) : this()
+        {
+            KnownTypes.AddRange(knownTypes);
+        }
+
+        /// <summary>
+        /// Creates a new empty <see cref="TypeGroup"/>.
+        /// </summary>
+        /// <param name="knownAssemblies">A collection of known <see cref="Assembly"/> references.</param>
+        /// <param name="knownTypes">A collection of known <see cref="Type"/> references.</param>
+        public TypeGroup(IEnumerable<Assembly> knownAssemblies, IEnumerable<Type> knownTypes) : this()
+        {
+            KnownAssemblies.AddRange(knownAssemblies);
+            KnownTypes.AddRange(knownTypes);
+        }
+
+
+        /// <summary>
+        /// Gets and verifies the <see cref="Type"/> represented by the given name.
+        /// </summary>
+        /// <param name="typeName">The <see cref="string"/> name of the type (see <see cref="Type.AssemblyQualifiedName"/>)</param>
+        /// <returns>The member <see cref="Type"/>, if found.</returns>
+        /// <exception cref="GraphTypeException">The type was not a member of this <see cref="TypeGroup"/>.</exception>
+        public Type GetMember(string typeName)
+        {
+            var type = Type.GetType(typeName);
+            VerifyType(type);
+            return type;
+        }
+
+        /// <summary>
+        /// Gets and verifies the <see cref="Type"/> represented by the given object.
+        /// </summary>
+        /// <param name="o">The given <see cref="object"/> to check.</param>
+        /// <returns>The <see cref="object"/>'s <see cref="Type"/>, if found.</returns>
+        /// <exception cref="GraphTypeException">The type was not a member of this <see cref="TypeGroup"/>.</exception>
+        public Type GetMember(object o)
+        {
+            var type = o.GetType();
+            VerifyType(type);
+            return type;
+        }
+
+        /// <summary>
+        /// Verifies the given <see cref="Type"/> to check it is a member of this <see cref="TypeGroup"/>.
+        /// </summary>
+        /// <exception cref="GraphTypeException">The type was not a member of this <see cref="TypeGroup"/>.</exception>
+        public void VerifyType(Type type)
+        {
+            if (!IsMember(type))
+            {
+                throw new GraphTypeException($"The type {type.FullName} of this object is not trusted.");
+            }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="bool"/> indicating whether the <see cref="Type"/> is a member of this <see cref="TypeGroup"/>.
+        /// </summary>
+        /// <param name="type">The given <see cref="Type"/>.</param>
+        public bool IsMember(Type type)
+        {
+            if (KnownAssemblies.Contains(type.Assembly))
+            {
+                return true;
+            }
+            else if (KnownTypes.Contains(type))
+            {
+                return true;
+            }
+
+            var trustedTypes = KnownAssemblies.SelectMany(a => a.GetTypes()).Concat(KnownTypes);
+            if (type.IsGenericType && trustedTypes.Contains(type.GetGenericTypeDefinition()))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/BassClefStudio.NET.Serialization/ICustomSerializer.cs
+++ b/BassClefStudio.NET.Serialization/ICustomSerializer.cs
@@ -1,0 +1,61 @@
+﻿using BassClefStudio.NET.Serialization.Graphs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BassClefStudio.NET.Serialization
+{
+    /// <summary>
+    /// Represents a service that can provide custom serialization for values in a <see cref="Graph"/>. Note that, since native <see cref="Graph"/> features don't support custom serialization, this is mainly for serializing value types.
+    /// </summary>
+    public interface ICustomSerializer
+    {
+        /// <summary>
+        /// A <see cref="TypeGroup"/> describing the <see cref="Type"/>s that this <see cref="ICustomSerializer"/> handles.
+        /// </summary>
+        TypeGroup ApplicableTypes { get; }
+
+        /// <summary>
+        /// Serializes an <see cref="object"/> (of a type described in <see cref="ApplicableTypes"/>) to a <see cref="string"/> value.
+        /// </summary>
+        /// <param name="o">The given <see cref="object"/> to serialize.</param>
+        /// <returns>A <see cref="string"/> suitable for serialization in <see cref="CustomValueNode.ValueString"/>.</returns>
+        string Serialize(object o);
+
+        /// <summary>
+        /// Deserializes a <see cref="string"/> representation (for one of the specified types in <see cref="ApplicableTypes"/>) into the <see cref="object"/> it represents.
+        /// </summary>
+        /// <param name="value">A previously-serialized <see cref="string"/> value.</param>
+        /// <returns>A <see cref="string"/> suitable for serialization in <see cref="CustomValueNode.ValueString"/>.</returns>
+        object Deserialize(string value);
+    }
+
+    /// <summary>
+    /// Contains extension methods for the <see cref="ICustomSerializer"/> interface.
+    /// </summary>
+    internal static class SerializerExtensions
+    {
+        /// <summary>
+        /// Checks whether any of the <see cref="ICustomSerializer"/>s in a collection is setup to handle the given <see cref="Type"/>.
+        /// </summary>
+        /// <param name="serializers">The collection of available <see cref="ICustomSerializer"/>s to handle <see cref="object"/>s.</param>
+        /// <param name="type">The desired <see cref="Type"/>.</param>
+        /// <returns>A <see cref="bool"/> indicating whether a <see cref="ICustomSerializer"/> in the collection handles this <paramref name="type"/>.</returns>
+        public static bool ContainsType(this IEnumerable<ICustomSerializer> serializers, Type type)
+        {
+            return serializers.Select(s => s.ApplicableTypes).Any(t => t.IsMember(type));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ICustomSerializer"/> in a collection that is setup to handle the given <see cref="Type"/>.
+        /// </summary>
+        /// <param name="serializers">The collection of available <see cref="ICustomSerializer"/>s to handle <see cref="object"/>s.</param>
+        /// <param name="type">The desired <see cref="Type"/>.</param>
+        /// <returns>The <see cref="ICustomSerializer"/> in the collection that handles this <paramref name="type"/>.</returns>
+        public static ICustomSerializer GetForType(this IEnumerable<ICustomSerializer> serializers, Type type)
+        {
+            return serializers.FirstOrDefault(s => s.ApplicableTypes.IsMember(type));
+        }
+    }
+}

--- a/BassClefStudio.NET.Serialization/SerializationService.cs
+++ b/BassClefStudio.NET.Serialization/SerializationService.cs
@@ -29,6 +29,17 @@ namespace BassClefStudio.NET.Serialization
         /// <summary>
         /// Creates a new <see cref="SerializationService"/>.
         /// </summary>
+        /// <param name="knownAssemblies">A collection of known <see cref="Assembly"/> references.</param>
+        /// <param name="defaultBehaviours">A set of <see cref="GraphBehaviour"/>s that will be applied to all trusted types in the <see cref="Graph"/>.</param>
+        public SerializationService(GraphBehaviour defaultBehaviours, params Assembly[] knownAssemblies)
+        {
+            Graph = new Graph(knownAssemblies);
+            Graph.Behaviours.Add(new GraphBehaviourInfo(Graph.TrustedTypes, defaultBehaviours));
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="SerializationService"/>.
+        /// </summary>
         /// <param name="knownTypes">A collection of known <see cref="Type"/> references.</param>
         public SerializationService(params Type[] knownTypes)
         {
@@ -38,11 +49,51 @@ namespace BassClefStudio.NET.Serialization
         /// <summary>
         /// Creates a new <see cref="SerializationService"/>.
         /// </summary>
+        /// <param name="knownTypes">A collection of known <see cref="Type"/> references.</param>
+        /// <param name="defaultBehaviours">A set of <see cref="GraphBehaviour"/>s that will be applied to all trusted types in the <see cref="Graph"/>.</param>
+        public SerializationService(GraphBehaviour defaultBehaviours, params Type[] knownTypes)
+        {
+            Graph = new Graph(knownTypes);
+            Graph.Behaviours.Add(new GraphBehaviourInfo(Graph.TrustedTypes, defaultBehaviours));
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="SerializationService"/>.
+        /// </summary>
         /// <param name="knownAssemblies">A collection of known <see cref="Assembly"/> references.</param>
         /// <param name="knownTypes">A collection of known <see cref="Type"/> references.</param>
-        public SerializationService(Assembly[] knownAssemblies, Type[] knownTypes)
+        /// <param name="defaultBehaviours">A set of <see cref="GraphBehaviour"/>s that will be applied to all trusted types in the <see cref="Graph"/>.</param>
+        public SerializationService(IEnumerable<Assembly> knownAssemblies, IEnumerable<Type> knownTypes, GraphBehaviour defaultBehaviours = GraphBehaviour.None)
         {
             Graph = new Graph(knownAssemblies, knownTypes);
+            Graph.Behaviours.Add(new GraphBehaviourInfo(Graph.TrustedTypes, defaultBehaviours));
+        }
+
+        /// <summary>
+        /// Adds a given specific <see cref="GraphBehaviourInfo"/> to the underlying <see cref="Graph"/>.
+        /// </summary>
+        /// <param name="behaviourInfo">The <see cref="GraphBehaviourInfo"/> behaviour.</param>
+        public void AddBehaviour(GraphBehaviourInfo behaviourInfo)
+        {
+            Graph.Behaviours.Add(behaviourInfo);
+        }
+
+        /// <summary>
+        /// Adds a custom <see cref="ICustomSerializer"/> serializer to the <see cref="SerializationService"/>.
+        /// </summary>
+        /// <param name="customSerializer">The <see cref="ICustomSerializer"/>s to add to the <see cref="SerializationService"/>'s <see cref="Graph"/>.</param>
+        public void AddCustomSerializer(ICustomSerializer customSerializer)
+        {
+            Graph.CustomSerializers.Add(customSerializer);
+        }
+
+        /// <summary>
+        /// Adds a collection of custom <see cref="ICustomSerializer"/> serializers to the <see cref="SerializationService"/>.
+        /// </summary>
+        /// <param name="customSerializers">The collection of <see cref="ICustomSerializer"/>s to add to the <see cref="SerializationService"/>'s <see cref="Graph"/>.</param>
+        public void AddCustomSerializers(IEnumerable<ICustomSerializer> customSerializers)
+        {
+            Graph.CustomSerializers.AddRange(customSerializers);
         }
 
         /// <summary>


### PR DESCRIPTION
Allowed for constructors to be called with no parameters (uninstantiated) or with parameters matching property names/types; added support for customization in the form of `ICustomSerializer` and the `GraphBehaviour` flags (both of which can selectively be applied to groups of types/assemblies via `TypeGroup`); and improved the ability of the serializer (through these methods as well as new serialization code) to handle serializing complex valuetypes such as `Vector2` natively (and other types like `Guid` with minimal extra code).