### PR TITLE
New ICustomSerializer improvements

### DIFF
--- a/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
+++ b/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
@@ -5,7 +5,7 @@
     <Authors>BassClefStudio</Authors>
     <Description>A new serialization engine that provides serialization and deserialization services for complex graphs of objects, preserving references and allowing for polymorphism of trusted types, while using JSON as the output format.</Description>
     <RepositoryUrl>https://github.com/bassclefstudio/.NET-Serialization.git</RepositoryUrl>
-    <Version>2.1.1</Version>
+    <Version>2.1.2</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.NET-Serialization</PackageProjectUrl>
     <PackageId>BassClefStudio.NET.Serialization</PackageId>
     <Product>BassClefStudio.NET.Serialization</Product>

--- a/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
+++ b/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
@@ -5,7 +5,7 @@
     <Authors>BassClefStudio</Authors>
     <Description>A new serialization engine that provides serialization and deserialization services for complex graphs of objects, preserving references and allowing for polymorphism of trusted types, while using JSON as the output format.</Description>
     <RepositoryUrl>https://github.com/bassclefstudio/.NET-Serialization.git</RepositoryUrl>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.NET-Serialization</PackageProjectUrl>
     <PackageId>BassClefStudio.NET.Serialization</PackageId>
     <Product>BassClefStudio.NET.Serialization</Product>
@@ -16,6 +16,7 @@
     <PackageReference Include="BassClefStudio.NET.Core" Version="1.4.0" />
     <PackageReference Include="JsonKnownTypes" Version="0.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/BassClefStudio.NET.Serialization/CustomTypes/GuidSerializer.cs
+++ b/BassClefStudio.NET.Serialization/CustomTypes/GuidSerializer.cs
@@ -1,0 +1,28 @@
+﻿using BassClefStudio.NET.Serialization.Graphs;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.NET.Serialization.CustomTypes
+{
+    /// <summary>
+    /// An <see cref="ICustomSerializer"/> for dealing with <see cref="Guid"/>s
+    /// </summary>
+    public class GuidSerializer : ICustomSerializer
+    {
+        /// <inheritdoc/>
+        public TypeGroup ApplicableTypes { get; } = new TypeGroup(typeof(Guid));
+
+        /// <inheritdoc/>
+        public object Deserialize(string value)
+        {
+            return Guid.Parse(value);
+        }
+
+        /// <inheritdoc/>
+        public string Serialize(object o)
+        {
+            return ((Guid)o).ToString("N");
+        }
+    }
+}

--- a/BassClefStudio.NET.Serialization/CustomTypes/VectorSerializer.cs
+++ b/BassClefStudio.NET.Serialization/CustomTypes/VectorSerializer.cs
@@ -1,0 +1,37 @@
+﻿using BassClefStudio.NET.Serialization.Graphs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+
+namespace BassClefStudio.NET.Serialization.CustomTypes
+{
+    /// <summary>
+    /// An <see cref="ICustomSerializer"/> for dealing with <see cref="Guid"/>s
+    /// </summary>
+    public class VectorSerializer : ICustomSerializer
+    {
+        /// <inheritdoc/>
+        public TypeGroup ApplicableTypes { get; } = new TypeGroup(typeof(Vector2));
+
+        /// <inheritdoc/>
+        public object Deserialize(string value)
+        {
+            var array = value.Split(new string[] { ";" }, StringSplitOptions.RemoveEmptyEntries);
+            if(array.Length != 2)
+            {
+                throw new GraphException("Vector2 serialization expects two float parameters.");
+            }
+            var fs = array.Select(c => float.Parse(c)).ToArray();
+            return new Vector2(fs[0], fs[1]);
+        }
+
+        /// <inheritdoc/>
+        public string Serialize(object o)
+        {
+            var v = (Vector2)o;
+            return $"{v.X};{v.Y}";
+        }
+    }
+}

--- a/BassClefStudio.NET.Serialization/CustomTypes/VectorSerializer.cs
+++ b/BassClefStudio.NET.Serialization/CustomTypes/VectorSerializer.cs
@@ -10,28 +10,19 @@ namespace BassClefStudio.NET.Serialization.CustomTypes
     /// <summary>
     /// An <see cref="ICustomSerializer"/> for dealing with <see cref="Guid"/>s
     /// </summary>
-    public class VectorSerializer : ICustomSerializer
+    public class VectorSerializer : CustomSerializer<Vector2>
     {
         /// <inheritdoc/>
-        public TypeGroup ApplicableTypes { get; } = new TypeGroup(typeof(Vector2));
+        public override Func<Vector2, object>[] GetProperties { get; } = new Func<Vector2, object>[]
+        {
+            v => v.X,
+            v => v.Y
+        };
 
         /// <inheritdoc/>
-        public object Deserialize(string value)
+        public override Vector2 DeserializeObject(string[] values)
         {
-            var array = value.Split(new string[] { ";" }, StringSplitOptions.RemoveEmptyEntries);
-            if(array.Length != 2)
-            {
-                throw new GraphException("Vector2 serialization expects two float parameters.");
-            }
-            var fs = array.Select(c => float.Parse(c)).ToArray();
-            return new Vector2(fs[0], fs[1]);
-        }
-
-        /// <inheritdoc/>
-        public string Serialize(object o)
-        {
-            var v = (Vector2)o;
-            return $"{v.X};{v.Y}";
+            return new Vector2(float.Parse(values[0]), float.Parse(values[1]));
         }
     }
 }

--- a/BassClefStudio.NET.Serialization/SerializationService.cs
+++ b/BassClefStudio.NET.Serialization/SerializationService.cs
@@ -1,4 +1,5 @@
-﻿using BassClefStudio.NET.Serialization.Graphs;
+﻿using BassClefStudio.NET.Serialization.CustomTypes;
+using BassClefStudio.NET.Serialization.Graphs;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -17,6 +18,12 @@ namespace BassClefStudio.NET.Serialization
         /// </summary>
         public Graph Graph { get; }
 
+        private static ICustomSerializer[] DefaultCustomSerializers = new ICustomSerializer[]
+        {
+            new GuidSerializer(),
+            new VectorSerializer()
+        };
+
         /// <summary>
         /// Creates a new <see cref="SerializationService"/>.
         /// </summary>
@@ -24,6 +31,7 @@ namespace BassClefStudio.NET.Serialization
         public SerializationService(params Assembly[] knownAssemblies)
         {
             Graph = new Graph(knownAssemblies);
+            AddCustomSerializers(DefaultCustomSerializers);
         }
 
         /// <summary>
@@ -31,9 +39,8 @@ namespace BassClefStudio.NET.Serialization
         /// </summary>
         /// <param name="knownAssemblies">A collection of known <see cref="Assembly"/> references.</param>
         /// <param name="defaultBehaviours">A set of <see cref="GraphBehaviour"/>s that will be applied to all trusted types in the <see cref="Graph"/>.</param>
-        public SerializationService(GraphBehaviour defaultBehaviours, params Assembly[] knownAssemblies)
+        public SerializationService(GraphBehaviour defaultBehaviours, params Assembly[] knownAssemblies) : this(knownAssemblies)
         {
-            Graph = new Graph(knownAssemblies);
             Graph.Behaviours.Add(new GraphBehaviourInfo(Graph.TrustedTypes, defaultBehaviours));
         }
 
@@ -44,6 +51,7 @@ namespace BassClefStudio.NET.Serialization
         public SerializationService(params Type[] knownTypes)
         {
             Graph = new Graph(knownTypes);
+            AddCustomSerializers(DefaultCustomSerializers);
         }
 
         /// <summary>
@@ -51,9 +59,8 @@ namespace BassClefStudio.NET.Serialization
         /// </summary>
         /// <param name="knownTypes">A collection of known <see cref="Type"/> references.</param>
         /// <param name="defaultBehaviours">A set of <see cref="GraphBehaviour"/>s that will be applied to all trusted types in the <see cref="Graph"/>.</param>
-        public SerializationService(GraphBehaviour defaultBehaviours, params Type[] knownTypes)
+        public SerializationService(GraphBehaviour defaultBehaviours, params Type[] knownTypes) : this(knownTypes)
         {
-            Graph = new Graph(knownTypes);
             Graph.Behaviours.Add(new GraphBehaviourInfo(Graph.TrustedTypes, defaultBehaviours));
         }
 
@@ -66,6 +73,7 @@ namespace BassClefStudio.NET.Serialization
         public SerializationService(IEnumerable<Assembly> knownAssemblies, IEnumerable<Type> knownTypes, GraphBehaviour defaultBehaviours = GraphBehaviour.None)
         {
             Graph = new Graph(knownAssemblies, knownTypes);
+            AddCustomSerializers(DefaultCustomSerializers);
             Graph.Behaviours.Add(new GraphBehaviourInfo(Graph.TrustedTypes, defaultBehaviours));
         }
 


### PR DESCRIPTION
Added new `ICustomSerializer` implementation (`CustomSerializer<T>`) to make it easier to serialize custom types such as structs. The `VectorSerializer` default serializer now uses this abstract implementation.