### PR TITLE
More Custom Type support

### DIFF
--- a/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
+++ b/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
@@ -5,7 +5,7 @@
     <Authors>BassClefStudio</Authors>
     <Description>A new serialization engine that provides serialization and deserialization services for complex graphs of objects, preserving references and allowing for polymorphism of trusted types, while using JSON as the output format.</Description>
     <RepositoryUrl>https://github.com/bassclefstudio/.NET-Serialization.git</RepositoryUrl>
-    <Version>2.1.2</Version>
+    <Version>2.2.0</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.NET-Serialization</PackageProjectUrl>
     <PackageId>BassClefStudio.NET.Serialization</PackageId>
     <Product>BassClefStudio.NET.Serialization</Product>

--- a/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
+++ b/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BassClefStudio.NET.Core" Version="1.4.0" />
+    <PackageReference Include="BassClefStudio.NET.Core" Version="1.5.0" />
     <PackageReference Include="JsonKnownTypes" Version="0.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />

--- a/BassClefStudio.NET.Serialization/CustomTypes/ColorSerializer.cs
+++ b/BassClefStudio.NET.Serialization/CustomTypes/ColorSerializer.cs
@@ -1,0 +1,28 @@
+﻿using BassClefStudio.NET.Core.Primitives;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.NET.Serialization.CustomTypes
+{
+    /// <summary>
+    /// An <see cref="ICustomSerializer"/> for dealing with <see cref="Color"/>s
+    /// </summary>
+    public class ColorSerializer : CustomSerializer<Color>
+    {
+        /// <inheritdoc/>
+        public override Func<Color, object>[] GetProperties { get; } = new Func<Color, object>[]
+        {
+            c => c.A,
+            c => c.R,
+            c => c.G,
+            c => c.B
+        };
+
+        /// <inheritdoc/>
+        public override Color DeserializeObject(string[] values)
+        {
+            return new Color(byte.Parse(values[1]), byte.Parse(values[2]), byte.Parse(values[3]), byte.Parse(values[0]));
+        }
+    }
+}

--- a/BassClefStudio.NET.Serialization/CustomTypes/TimeSerializers.cs
+++ b/BassClefStudio.NET.Serialization/CustomTypes/TimeSerializers.cs
@@ -1,0 +1,55 @@
+﻿using BassClefStudio.NET.Core.Primitives;
+using BassClefStudio.NET.Serialization.Graphs;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.NET.Serialization.CustomTypes
+{
+    /// <summary>
+    /// An <see cref="ICustomSerializer"/> for dealing with <see cref="DateTimeOffset"/>s.
+    /// </summary>
+    public class DateTimeOffsetSerializer : ICustomSerializer
+    {
+        /// <inheritdoc/>
+        public TypeGroup ApplicableTypes { get; } = new TypeGroup(typeof(DateTimeOffset));
+
+        /// <inheritdoc/>
+        public object Deserialize(string value)
+        {
+            return DateTimeOffset.Parse(value);
+        }
+
+        /// <inheritdoc/>
+        public string Serialize(object o)
+        {
+            if (o is DateTimeOffset offset)
+            {
+                return offset.ToString();
+            }
+            else
+            {
+                throw new ArgumentException($"DateTimeOffsetSerializer expects objects of type DateTimeOffset - object type {o?.GetType().Name}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="ICustomSerializer"/> for dealing with <see cref="DateTimeSpan"/>s.
+    /// </summary>
+    public class DateTimeSpanSerializer : CustomSerializer<DateTimeSpan>
+    {
+        /// <inheritdoc/>
+        public override Func<DateTimeSpan, object>[] GetProperties { get; } = new Func<DateTimeSpan, object>[]
+        {
+            v => v.StartDate,
+            v => v.EndDate
+        };
+
+        /// <inheritdoc/>
+        public override DateTimeSpan DeserializeObject(string[] values)
+        {
+            return new DateTimeSpan(DateTimeOffset.Parse(values[0]), DateTimeOffset.Parse(values[1]));
+        }
+    }
+}

--- a/BassClefStudio.NET.Serialization/Graphs/Graph.cs
+++ b/BassClefStudio.NET.Serialization/Graphs/Graph.cs
@@ -48,7 +48,9 @@ namespace BassClefStudio.NET.Serialization.Graphs
             typeof(ObservableCollection<>),
             typeof(Vector2),
             typeof(Guid),
-            typeof(DateTimeOffset)
+            typeof(DateTimeOffset),
+            typeof(Color),
+            typeof(DateTimeSpan)
         };
 
         /// <summary>
@@ -56,8 +58,6 @@ namespace BassClefStudio.NET.Serialization.Graphs
         /// </summary>
         public static Assembly[] DefaultTrustedAssemblies { get; } = new Assembly[]
         {
-            typeof(Graph).Assembly,
-            typeof(Color).Assembly
         };
 
         private int Index = 0;

--- a/BassClefStudio.NET.Serialization/Graphs/Graph.cs
+++ b/BassClefStudio.NET.Serialization/Graphs/Graph.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using BassClefStudio.NET.Core.Primitives;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections;
@@ -6,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Numerics;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
@@ -43,7 +45,19 @@ namespace BassClefStudio.NET.Serialization.Graphs
         public static Type[] DefaultTrustedTypes { get; } = new Type[]
         {
             typeof(List<>),
-            typeof(ObservableCollection<>)
+            typeof(ObservableCollection<>),
+            typeof(Vector2),
+            typeof(Guid),
+            typeof(DateTimeOffset)
+        };
+
+        /// <summary>
+        /// Gets the static array of <see cref="Type"/>s that the <see cref="Graph"/> trusts by default. This includes basic types for collections such as <see cref="List{T}"/>.
+        /// </summary>
+        public static Assembly[] DefaultTrustedAssemblies { get; } = new Assembly[]
+        {
+            typeof(Graph).Assembly,
+            typeof(Color).Assembly
         };
 
         private int Index = 0;
@@ -52,8 +66,10 @@ namespace BassClefStudio.NET.Serialization.Graphs
             Nodes = new List<Node>();
             Behaviours = new List<GraphBehaviourInfo>();
             CustomSerializers = new List<ICustomSerializer>();
+
             TrustedTypes = new TypeGroup();
             TrustedTypes.KnownTypes.AddRange(DefaultTrustedTypes);
+            TrustedTypes.KnownAssemblies.AddRange(DefaultTrustedAssemblies);
         }
 
         /// <summary>

--- a/BassClefStudio.NET.Serialization/SerializationService.cs
+++ b/BassClefStudio.NET.Serialization/SerializationService.cs
@@ -67,10 +67,10 @@ namespace BassClefStudio.NET.Serialization
         /// <summary>
         /// Creates a new <see cref="SerializationService"/>.
         /// </summary>
+        /// <param name="defaultBehaviours">A set of <see cref="GraphBehaviour"/>s that will be applied to all trusted types in the <see cref="Graph"/>.</param>
         /// <param name="knownAssemblies">A collection of known <see cref="Assembly"/> references.</param>
         /// <param name="knownTypes">A collection of known <see cref="Type"/> references.</param>
-        /// <param name="defaultBehaviours">A set of <see cref="GraphBehaviour"/>s that will be applied to all trusted types in the <see cref="Graph"/>.</param>
-        public SerializationService(IEnumerable<Assembly> knownAssemblies, IEnumerable<Type> knownTypes, GraphBehaviour defaultBehaviours = GraphBehaviour.None)
+        public SerializationService(GraphBehaviour defaultBehaviours, IEnumerable<Assembly> knownAssemblies, IEnumerable<Type> knownTypes)
         {
             Graph = new Graph(knownAssemblies, knownTypes);
             AddCustomSerializers(DefaultCustomSerializers);

--- a/BassClefStudio.NET.Serialization/SerializationService.cs
+++ b/BassClefStudio.NET.Serialization/SerializationService.cs
@@ -78,6 +78,18 @@ namespace BassClefStudio.NET.Serialization
         }
 
         /// <summary>
+        /// Creates a new <see cref="SerializationService"/>.
+        /// </summary>
+        /// <param name="knownAssemblies">A collection of known <see cref="Assembly"/> references.</param>
+        /// <param name="knownTypes">A collection of known <see cref="Type"/> references.</param>
+        public SerializationService(IEnumerable<Assembly> knownAssemblies, IEnumerable<Type> knownTypes)
+        {
+            Graph = new Graph(knownAssemblies, knownTypes);
+            AddCustomSerializers(DefaultCustomSerializers);
+            Graph.Behaviours.Add(new GraphBehaviourInfo(Graph.TrustedTypes, GraphBehaviour.None));
+        }
+
+        /// <summary>
         /// Adds a given specific <see cref="GraphBehaviourInfo"/> to the underlying <see cref="Graph"/>.
         /// </summary>
         /// <param name="behaviourInfo">The <see cref="GraphBehaviourInfo"/> behaviour.</param>


### PR DESCRIPTION
[.NET-Libraries](https://github.com/bassclefstudio/.NET-Libraries) types `Color` and `DateTimeRange` now have native support from new `ICustomSerializer`s. This PR also fixes some inconsistencies in constructor parameter order for the `SerializationService` class.