### PR TITLE
v2.2.1 - Array custom support

### DIFF
--- a/BassClefStudio.NET.Serialization.Tests/SerializerTests.cs
+++ b/BassClefStudio.NET.Serialization.Tests/SerializerTests.cs
@@ -2,6 +2,7 @@ using BassClefStudio.NET.Serialization.Graphs;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using System.Reflection;
 
@@ -60,17 +61,37 @@ namespace BassClefStudio.NET.Serialization.Tests
             Base b = new Base();
             Base c = new Base();
             Base d = new Base();
-            ListDerived e = new ListDerived() { Child = a, Parents = new List<Base>() { a, b, c, d } };
+            CollectionDerived e = new CollectionDerived() { Child = a, Parents = new List<Base>() { a, b, c, d } };
 
             var serializer = new SerializationService(typeof(SerializerTests).Assembly);
             string json = serializer.Serialize(e);
             Console.WriteLine(json);
             Base newE = serializer.Deserialize<Base>(json);
-            Assert.IsInstanceOfType(newE, typeof(ListDerived));
-            var listE = (ListDerived)newE;
+            Assert.IsInstanceOfType(newE, typeof(CollectionDerived));
+            var listE = (CollectionDerived)newE;
             Assert.IsNotNull(listE.Parents);
-            Assert.AreEqual(4, listE.Parents.Count);
-            Assert.AreEqual(listE.Child, listE.Parents[0]);
+            Assert.AreEqual(4, listE.Parents.Count());
+            Assert.AreEqual(listE.Child, listE.Parents.ElementAt(0));
+        }
+
+        [TestMethod]
+        public void TestArray()
+        {
+            Base a = new Base();
+            Base b = new Base();
+            Base c = new Base();
+            Base d = new Base();
+            CollectionDerived e = new CollectionDerived() { Child = a, Parents = new Base[] { a, b, c, d } };
+
+            var serializer = new SerializationService(typeof(SerializerTests).Assembly);
+            string json = serializer.Serialize(e);
+            Console.WriteLine(json);
+            Base newE = serializer.Deserialize<Base>(json);
+            Assert.IsInstanceOfType(newE, typeof(CollectionDerived));
+            var listE = (CollectionDerived)newE;
+            Assert.IsNotNull(listE.Parents);
+            Assert.AreEqual(4, listE.Parents.Count());
+            Assert.AreEqual(listE.Child, listE.Parents.ElementAt(0));
         }
 
         [TestMethod]
@@ -147,9 +168,9 @@ namespace BassClefStudio.NET.Serialization.Tests
         }
     }
 
-    public class ListDerived : Base
+    public class CollectionDerived : Base
     {
-        public List<Base> Parents { get; set; }
+        public IEnumerable<Base> Parents { get; set; }
     }
 
     public class GuidSerializer : ICustomSerializer

--- a/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
+++ b/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
@@ -5,7 +5,7 @@
     <Authors>BassClefStudio</Authors>
     <Description>A new serialization engine that provides serialization and deserialization services for complex graphs of objects, preserving references and allowing for polymorphism of trusted types, while using JSON as the output format.</Description>
     <RepositoryUrl>https://github.com/bassclefstudio/.NET-Serialization.git</RepositoryUrl>
-    <Version>2.2.0</Version>
+    <Version>2.2.1</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.NET-Serialization</PackageProjectUrl>
     <PackageId>BassClefStudio.NET.Serialization</PackageId>
     <Product>BassClefStudio.NET.Serialization</Product>

--- a/BassClefStudio.NET.Serialization/Graphs/Graph.cs
+++ b/BassClefStudio.NET.Serialization/Graphs/Graph.cs
@@ -46,6 +46,7 @@ namespace BassClefStudio.NET.Serialization.Graphs
         {
             typeof(List<>),
             typeof(ObservableCollection<>),
+            typeof(Array),
             typeof(Vector2),
             typeof(Guid),
             typeof(DateTimeOffset),
@@ -280,6 +281,20 @@ namespace BassClefStudio.NET.Serialization.Graphs
                                 }
                             }
                         }
+                        else if (node is CollectionNode collectionNode && nodeType.IsArray)
+                        {
+                            int length = collectionNode.Children.Count;
+                            var arrayConst = nodeType.GetConstructor(new[] { typeof(int) });
+                            if (arrayConst != null)
+                            {
+                                node.BasedOn = arrayConst.Invoke(new object[] { length });
+                                isConstructed = true;
+                            }
+                            else
+                            {
+                                throw new GraphException($"Could not create new instance of array {collectionNode.MyLink} - no valid array constructor found.");
+                            }
+                        }
                         else
                         {
                             var emptyConstructor = myConstructors.FirstOrDefault(c => !c.GetParameters().Any());
@@ -325,6 +340,7 @@ namespace BassClefStudio.NET.Serialization.Graphs
                     //// Collection initialization
                     if (collectionNode.BasedOn is IList list)
                     {
+                        //// List initialization
                         try
                         {
                             foreach (var item in collectionNode.Children)
@@ -337,9 +353,24 @@ namespace BassClefStudio.NET.Serialization.Graphs
                             throw new GraphException($"Failed to add items to collection [{node.MyLink}].", ex);
                         }
                     }
+                    else if(collectionNode.BasedOn is Array array)
+                    {
+                        //// Array initialization
+                        try
+                        {
+                            for (int i = 0; i < collectionNode.Children.Count; i++)
+                            {
+                                array.SetValue(collectionNode.Children[i], i);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new GraphException($"Failed to add items to array [{node.MyLink}].", ex);
+                        }
+                    }
                     else
                     {
-                        throw new GraphException($"Collection initialization currently does not support anything other than IList<T>. Type: {type.FullName}");
+                        throw new GraphException($"Collection initialization currently does not support anything other than arrays or IList<T>. Type: {type.FullName}");
                     }
                 }
                 else

--- a/BassClefStudio.NET.Serialization/Graphs/Graph.cs
+++ b/BassClefStudio.NET.Serialization/Graphs/Graph.cs
@@ -338,7 +338,22 @@ namespace BassClefStudio.NET.Serialization.Graphs
                 else if (node is CollectionNode collectionNode)
                 {
                     //// Collection initialization
-                    if (collectionNode.BasedOn is IList list)
+                    if (collectionNode.BasedOn is Array array)
+                    {
+                        //// Array initialization
+                        try
+                        {
+                            for (int i = 0; i < collectionNode.Children.Count; i++)
+                            {
+                                array.SetValue(nodeBuilders[collectionNode.Children[i]].BasedOn, i);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new GraphException($"Failed to add items to array [{node.MyLink}].", ex);
+                        }
+                    }
+                    else if (collectionNode.BasedOn is IList list)
                     {
                         //// List initialization
                         try
@@ -350,24 +365,9 @@ namespace BassClefStudio.NET.Serialization.Graphs
                         }
                         catch (Exception ex)
                         {
-                            throw new GraphException($"Failed to add items to collection [{node.MyLink}].", ex);
+                            throw new GraphException($"Failed to add items to list [{node.MyLink}].", ex);
                         }
-                    }
-                    else if(collectionNode.BasedOn is Array array)
-                    {
-                        //// Array initialization
-                        try
-                        {
-                            for (int i = 0; i < collectionNode.Children.Count; i++)
-                            {
-                                array.SetValue(collectionNode.Children[i], i);
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            throw new GraphException($"Failed to add items to array [{node.MyLink}].", ex);
-                        }
-                    }
+                    } 
                     else
                     {
                         throw new GraphException($"Collection initialization currently does not support anything other than arrays or IList<T>. Type: {type.FullName}");

--- a/BassClefStudio.NET.Serialization/Graphs/TypeGroup.cs
+++ b/BassClefStudio.NET.Serialization/Graphs/TypeGroup.cs
@@ -119,6 +119,11 @@ namespace BassClefStudio.NET.Serialization.Graphs
                 return true;
             }
 
+            if(trustedTypes.Contains(typeof(Array)) && type.IsArray)
+            {
+                return true;
+            }
+
             return false;
         }
     }


### PR DESCRIPTION
Custom support built natively into `Graph` for serializing `Array`s of items, recognizing them as one of the natively trusted types (along with `ObservableCollection<T>` and `List<T>`)