### PR TITLE
v2.2.2 - more native type serialization

### DIFF
--- a/BassClefStudio.NET.Serialization.Tests/SerializerTests.cs
+++ b/BassClefStudio.NET.Serialization.Tests/SerializerTests.cs
@@ -1,3 +1,4 @@
+using BassClefStudio.NET.Core.Primitives;
 using BassClefStudio.NET.Serialization.Graphs;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
@@ -127,13 +128,55 @@ namespace BassClefStudio.NET.Serialization.Tests
             GuidDerived a = new GuidDerived() { Child = null, Id = Guid.NewGuid() };
             Base b = new Base() { Child = a };
             var serializer = new SerializationService(new Assembly[] { typeof(SerializerTests).Assembly }, new Type[] { typeof(Guid) });
-            serializer.AddCustomSerializer(new GuidSerializer());
             string json = serializer.Serialize(b);
             Console.WriteLine(json);
             Base newB = serializer.Deserialize<Base>(json);
             Assert.IsInstanceOfType(newB.Child, typeof(GuidDerived));
             Assert.AreEqual(a.Id, ((GuidDerived)newB.Child).Id);
         }
+
+        #region ValueTypes
+
+        private void TestValue<T>(T value)
+        {
+            var serializer = new SerializationService(new Assembly[] { typeof(SerializerTests).Assembly }, new Type[] { typeof(Guid) });
+            string json = serializer.Serialize(value);
+            Console.WriteLine(json);
+            T newVal = serializer.Deserialize<T>(json);
+            Assert.AreEqual(value, newVal, $"Value type serialization failed on {typeof(T).Name} native serializer.");
+        }
+
+        [TestMethod]
+        public void ColorTest()
+        {
+            Color color = new Color(130, 147, 89, 190);
+            TestValue(color);
+        }
+
+        [TestMethod]
+        public void GuidTest()
+        {
+            Guid id = Guid.NewGuid();
+            TestValue(id);
+        }
+
+        [TestMethod]
+        public void TimeTest()
+        {
+            DateTimeOffset offset = new DateTimeOffset(new DateTime(2021, 8, 30));
+            TestValue(offset);
+            DateTimeSpan span = new DateTimeSpan(offset, new TimeSpan(4, 33, 0));
+            TestValue(span);
+        }
+
+        [TestMethod]
+        public void VectorTest()
+        {
+            Vector2 vector = new Vector2(470, -132);
+            TestValue(vector);
+        }
+
+        #endregion
     }
 
     public class Base

--- a/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
+++ b/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
@@ -5,7 +5,7 @@
     <Authors>BassClefStudio</Authors>
     <Description>A new serialization engine that provides serialization and deserialization services for complex graphs of objects, preserving references and allowing for polymorphism of trusted types, while using JSON as the output format.</Description>
     <RepositoryUrl>https://github.com/bassclefstudio/.NET-Serialization.git</RepositoryUrl>
-    <Version>2.2.1</Version>
+    <Version>2.2.2</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.NET-Serialization</PackageProjectUrl>
     <PackageId>BassClefStudio.NET.Serialization</PackageId>
     <Product>BassClefStudio.NET.Serialization</Product>

--- a/BassClefStudio.NET.Serialization/CustomTypes/GuidSerializer.cs
+++ b/BassClefStudio.NET.Serialization/CustomTypes/GuidSerializer.cs
@@ -8,21 +8,18 @@ namespace BassClefStudio.NET.Serialization.CustomTypes
     /// <summary>
     /// An <see cref="ICustomSerializer"/> for dealing with <see cref="Guid"/>s
     /// </summary>
-    public class GuidSerializer : ICustomSerializer
+    public class GuidSerializer : StringSerializer<Guid>
     {
         /// <inheritdoc/>
-        public TypeGroup ApplicableTypes { get; } = new TypeGroup(typeof(Guid));
-
-        /// <inheritdoc/>
-        public object Deserialize(string value)
+        public override Guid ParseValue(string value)
         {
             return Guid.Parse(value);
         }
 
         /// <inheritdoc/>
-        public string Serialize(object o)
+        public override string GetString(Guid value)
         {
-            return ((Guid)o).ToString("N");
+            return value.ToString("N");
         }
     }
 }

--- a/BassClefStudio.NET.Serialization/CustomTypes/NativeTypes.cs
+++ b/BassClefStudio.NET.Serialization/CustomTypes/NativeTypes.cs
@@ -1,0 +1,51 @@
+﻿using BassClefStudio.NET.Core.Primitives;
+using BassClefStudio.NET.Serialization.Graphs;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Numerics;
+using System.Reflection;
+using System.Text;
+
+namespace BassClefStudio.NET.Serialization.CustomTypes
+{
+    /// <summary>
+    /// Represents static properties that manage the lists of natively trusted types, assemblies, and <see cref="ICustomSerializer"/>s.
+    /// </summary>
+    public static class NativeTypes
+    {
+        /// <summary>
+        /// Gets a static collection of <see cref="ICustomSerializer"/>s that can be added by default to <see cref="Graph"/>s.
+        /// </summary>
+        public static ICustomSerializer[] DefaultCustomSerializers { get; } = new ICustomSerializer[]
+        {
+            new ColorSerializer(),
+            new GuidSerializer(),
+            new VectorSerializer(),
+            new DateTimeOffsetSerializer(),
+            new DateTimeSpanSerializer()
+        };
+
+        /// <summary>
+        /// Gets the static array of <see cref="Type"/>s that <see cref="Graph"/>s trust by default. This includes basic types for collections such as <see cref="List{T}"/>.
+        /// </summary>
+        public static Type[] DefaultTrustedTypes { get; } = new Type[]
+        {
+            typeof(List<>),
+            typeof(ObservableCollection<>),
+            typeof(Array),
+            typeof(Vector2),
+            typeof(Guid),
+            typeof(DateTimeOffset),
+            typeof(Color),
+            typeof(DateTimeSpan)
+        };
+
+        /// <summary>
+        /// Gets the static array of <see cref="Assembly"/>s that <see cref="Graph"/>s trust by default.
+        /// </summary>
+        public static Assembly[] DefaultTrustedAssemblies { get; } = new Assembly[]
+        {
+        };
+    }
+}

--- a/BassClefStudio.NET.Serialization/CustomTypes/TimeSerializers.cs
+++ b/BassClefStudio.NET.Serialization/CustomTypes/TimeSerializers.cs
@@ -9,28 +9,12 @@ namespace BassClefStudio.NET.Serialization.CustomTypes
     /// <summary>
     /// An <see cref="ICustomSerializer"/> for dealing with <see cref="DateTimeOffset"/>s.
     /// </summary>
-    public class DateTimeOffsetSerializer : ICustomSerializer
+    public class DateTimeOffsetSerializer : StringSerializer<DateTimeOffset>
     {
         /// <inheritdoc/>
-        public TypeGroup ApplicableTypes { get; } = new TypeGroup(typeof(DateTimeOffset));
-
-        /// <inheritdoc/>
-        public object Deserialize(string value)
+        public override DateTimeOffset ParseValue(string value)
         {
             return DateTimeOffset.Parse(value);
-        }
-
-        /// <inheritdoc/>
-        public string Serialize(object o)
-        {
-            if (o is DateTimeOffset offset)
-            {
-                return offset.ToString();
-            }
-            else
-            {
-                throw new ArgumentException($"DateTimeOffsetSerializer expects objects of type DateTimeOffset - object type {o?.GetType().Name}");
-            }
         }
     }
 

--- a/BassClefStudio.NET.Serialization/Graphs/Graph.cs
+++ b/BassClefStudio.NET.Serialization/Graphs/Graph.cs
@@ -1,4 +1,5 @@
 ﻿using BassClefStudio.NET.Core.Primitives;
+using BassClefStudio.NET.Serialization.CustomTypes;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -39,28 +40,6 @@ namespace BassClefStudio.NET.Serialization.Graphs
         /// </summary>
         public List<ICustomSerializer> CustomSerializers { get; }
 
-        /// <summary>
-        /// Gets the static array of <see cref="Type"/>s that the <see cref="Graph"/> trusts by default. This includes basic types for collections such as <see cref="List{T}"/>.
-        /// </summary>
-        public static Type[] DefaultTrustedTypes { get; } = new Type[]
-        {
-            typeof(List<>),
-            typeof(ObservableCollection<>),
-            typeof(Array),
-            typeof(Vector2),
-            typeof(Guid),
-            typeof(DateTimeOffset),
-            typeof(Color),
-            typeof(DateTimeSpan)
-        };
-
-        /// <summary>
-        /// Gets the static array of <see cref="Type"/>s that the <see cref="Graph"/> trusts by default. This includes basic types for collections such as <see cref="List{T}"/>.
-        /// </summary>
-        public static Assembly[] DefaultTrustedAssemblies { get; } = new Assembly[]
-        {
-        };
-
         private int Index = 0;
         private Graph()
         {
@@ -69,8 +48,8 @@ namespace BassClefStudio.NET.Serialization.Graphs
             CustomSerializers = new List<ICustomSerializer>();
 
             TrustedTypes = new TypeGroup();
-            TrustedTypes.KnownTypes.AddRange(DefaultTrustedTypes);
-            TrustedTypes.KnownAssemblies.AddRange(DefaultTrustedAssemblies);
+            TrustedTypes.KnownTypes.AddRange(NativeTypes.DefaultTrustedTypes);
+            TrustedTypes.KnownAssemblies.AddRange(NativeTypes.DefaultTrustedAssemblies);
         }
 
         /// <summary>

--- a/BassClefStudio.NET.Serialization/ICustomSerializer.cs
+++ b/BassClefStudio.NET.Serialization/ICustomSerializer.cs
@@ -32,9 +32,9 @@ namespace BassClefStudio.NET.Serialization
     }
 
     /// <summary>
-    /// A base implementation of <see cref="ICustomSerializer"/> that provides basic <see cref="string"/> serialization for a single type.
+    /// A base implementation of <see cref="ICustomSerializer"/> that provides basic <see cref="string"/> serialization of properties for a single type.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">The type of object this <see cref="CustomSerializer{T}"/> serializes.</typeparam>
     public abstract class CustomSerializer<T> : ICustomSerializer
     {
         /// <inheritdoc/>
@@ -74,6 +74,48 @@ namespace BassClefStudio.NET.Serialization
             if(o is T t)
             {
                 return string.Join(Delimiter, GetProperties.Select(p => p(t)).ToArray());
+            }
+            else
+            {
+                throw new ArgumentException($"Serializer expected type {typeof(T).Name} - recieved {o?.GetType().Name}.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// A base implementation of <see cref="ICustomSerializer"/> that provides basic <see cref="object.ToString"/> and object parsing serialization for a single type.
+    /// </summary>
+    /// <typeparam name="T">The type of object this <see cref="StringSerializer{T}"/> serializes.</typeparam>
+    public abstract class StringSerializer<T> : ICustomSerializer
+    {
+        /// <inheritdoc/>
+        public TypeGroup ApplicableTypes { get; } = new TypeGroup(typeof(T));
+
+        /// <summary>
+        /// A function that, given a <see cref="string"/> representation, can parse a <typeparamref name="T"/> object value.
+        /// </summary>
+        public abstract T ParseValue(string value);
+
+        /// <summary>
+        /// A function that, given a <typeparamref name="T"/> object, produces a <see cref="string"/> representation.
+        /// </summary>
+        public virtual string GetString(T value)
+        {
+            return value.ToString();
+        }
+
+        /// <inheritdoc/>
+        public object Deserialize(string value)
+        {
+            return ParseValue(value);
+        }
+
+        /// <inheritdoc/>
+        public string Serialize(object o)
+        {
+            if (o is T t)
+            {
+                return GetString(t);
             }
             else
             {

--- a/BassClefStudio.NET.Serialization/SerializationService.cs
+++ b/BassClefStudio.NET.Serialization/SerializationService.cs
@@ -18,12 +18,6 @@ namespace BassClefStudio.NET.Serialization
         /// </summary>
         public Graph Graph { get; }
 
-        private static ICustomSerializer[] DefaultCustomSerializers = new ICustomSerializer[]
-        {
-            new GuidSerializer(),
-            new VectorSerializer()
-        };
-
         /// <summary>
         /// Creates a new <see cref="SerializationService"/>.
         /// </summary>
@@ -31,7 +25,7 @@ namespace BassClefStudio.NET.Serialization
         public SerializationService(params Assembly[] knownAssemblies)
         {
             Graph = new Graph(knownAssemblies);
-            AddCustomSerializers(DefaultCustomSerializers);
+            AddCustomSerializers(NativeTypes.DefaultCustomSerializers);
         }
 
         /// <summary>
@@ -51,7 +45,7 @@ namespace BassClefStudio.NET.Serialization
         public SerializationService(params Type[] knownTypes)
         {
             Graph = new Graph(knownTypes);
-            AddCustomSerializers(DefaultCustomSerializers);
+            AddCustomSerializers(NativeTypes.DefaultCustomSerializers);
         }
 
         /// <summary>
@@ -73,7 +67,7 @@ namespace BassClefStudio.NET.Serialization
         public SerializationService(GraphBehaviour defaultBehaviours, IEnumerable<Assembly> knownAssemblies, IEnumerable<Type> knownTypes)
         {
             Graph = new Graph(knownAssemblies, knownTypes);
-            AddCustomSerializers(DefaultCustomSerializers);
+            AddCustomSerializers(NativeTypes.DefaultCustomSerializers);
             Graph.Behaviours.Add(new GraphBehaviourInfo(Graph.TrustedTypes, defaultBehaviours));
         }
 
@@ -85,7 +79,7 @@ namespace BassClefStudio.NET.Serialization
         public SerializationService(IEnumerable<Assembly> knownAssemblies, IEnumerable<Type> knownTypes)
         {
             Graph = new Graph(knownAssemblies, knownTypes);
-            AddCustomSerializers(DefaultCustomSerializers);
+            AddCustomSerializers(NativeTypes.DefaultCustomSerializers);
             Graph.Behaviours.Add(new GraphBehaviourInfo(Graph.TrustedTypes, GraphBehaviour.None));
         }
 


### PR DESCRIPTION
Adjusted the native type serialization to make it easier to augment as well as internally manage. This includes a new `StringSerializer<T>` abstract class that you can implement to make creating `ICustomSerializer`s easier.