### PR TITLE
Added new serializer to NativeTypes for the new DateTimeZone primitive

### DIFF
--- a/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
+++ b/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
@@ -5,7 +5,7 @@
     <Authors>BassClefStudio</Authors>
     <Description>A new serialization engine that provides serialization and deserialization services for complex graphs of objects, preserving references and allowing for polymorphism of trusted types, while using JSON as the output format.</Description>
     <RepositoryUrl>https://github.com/bassclefstudio/.NET-Serialization.git</RepositoryUrl>
-    <Version>2.2.2</Version>
+    <Version>2.2.3</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.NET-Serialization</PackageProjectUrl>
     <PackageId>BassClefStudio.NET.Serialization</PackageId>
     <Product>BassClefStudio.NET.Serialization</Product>
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BassClefStudio.NET.Core" Version="1.5.0" />
+    <PackageReference Include="BassClefStudio.NET.Core" Version="1.5.2" />
     <PackageReference Include="JsonKnownTypes" Version="0.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />

--- a/BassClefStudio.NET.Serialization/CustomTypes/NativeTypes.cs
+++ b/BassClefStudio.NET.Serialization/CustomTypes/NativeTypes.cs
@@ -23,6 +23,7 @@ namespace BassClefStudio.NET.Serialization.CustomTypes
             new GuidSerializer(),
             new VectorSerializer(),
             new DateTimeOffsetSerializer(),
+            new DateTimeZoneSerializer(),
             new DateTimeSpanSerializer()
         };
 
@@ -37,6 +38,7 @@ namespace BassClefStudio.NET.Serialization.CustomTypes
             typeof(Vector2),
             typeof(Guid),
             typeof(DateTimeOffset),
+            typeof(DateTimeZone),
             typeof(Color),
             typeof(DateTimeSpan)
         };

--- a/BassClefStudio.NET.Serialization/CustomTypes/TimeSerializers.cs
+++ b/BassClefStudio.NET.Serialization/CustomTypes/TimeSerializers.cs
@@ -19,6 +19,25 @@ namespace BassClefStudio.NET.Serialization.CustomTypes
     }
 
     /// <summary>
+    /// An <see cref="ICustomSerializer"/> for dealing with <see cref="DateTimeZone"/>s.
+    /// </summary>
+    public class DateTimeZoneSerializer : CustomSerializer<DateTimeZone>
+    {
+        /// <inheritdoc/>
+        public override Func<DateTimeZone, object>[] GetProperties { get; } = new Func<DateTimeZone, object>[]
+        {
+            d => d.DateTime,
+            d => d.TimeZone.Id
+        };
+
+        /// <inheritdoc/>
+        public override DateTimeZone DeserializeObject(string[] values)
+        {
+            return new DateTimeZone(DateTime.Parse(values[0]), TimeZoneInfo.FindSystemTimeZoneById(values[1]));
+        }
+    }
+
+    /// <summary>
     /// An <see cref="ICustomSerializer"/> for dealing with <see cref="DateTimeSpan"/>s.
     /// </summary>
     public class DateTimeSpanSerializer : CustomSerializer<DateTimeSpan>


### PR DESCRIPTION
`DateTimeZoneSerializer` serializes the new BassClefStudio.NET.Core.Primitives struct.