### PR TITLE
v2.3.0 - 'Native' types now use ICustomSerializer instead of default JSON serialization

### DIFF
--- a/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
+++ b/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BassClefStudio.NET.Core" Version="1.5.4" />
-    <PackageReference Include="JsonKnownTypes" Version="0.5.3" />
+    <PackageReference Include="BassClefStudio.NET.Core" Version="2.0.0" />
+    <PackageReference Include="JsonKnownTypes" Version="0.5.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>

--- a/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
+++ b/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
@@ -5,7 +5,7 @@
     <Authors>BassClefStudio</Authors>
     <Description>A new serialization engine that provides serialization and deserialization services for complex graphs of objects, preserving references and allowing for polymorphism of trusted types, while using JSON as the output format.</Description>
     <RepositoryUrl>https://github.com/bassclefstudio/.NET-Serialization.git</RepositoryUrl>
-    <Version>2.2.7</Version>
+    <Version>2.3.0</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.NET-Serialization</PackageProjectUrl>
     <PackageId>BassClefStudio.NET.Serialization</PackageId>
     <Product>BassClefStudio.NET.Serialization</Product>

--- a/BassClefStudio.NET.Serialization/CustomTypes/NativeSerializers.cs
+++ b/BassClefStudio.NET.Serialization/CustomTypes/NativeSerializers.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.NET.Serialization.CustomTypes
+{
+    /// <summary>
+    /// Native serializer for <see cref="string"/> values.
+    /// </summary>
+    public class StringSerializer : StringSerializer<string>
+    {
+        /// <inheritdoc/>
+        public override string ParseValue(string value)
+        {
+            return value;
+        }
+
+        /// <inheritdoc/>
+        public override string GetString(string value)
+        {
+            return value;
+        }
+    }
+
+    /// <summary>
+    /// Native serializer for <see cref="int"/> values.
+    /// </summary>
+    public class IntSerializer : StringSerializer<int>
+    {
+        /// <inheritdoc/>
+        public override int ParseValue(string value)
+        {
+            return int.Parse(value);
+        }
+
+        /// <inheritdoc/>
+        public override string GetString(int value)
+        {
+            return value.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Native serializer for <see cref="long"/> values.
+    /// </summary>
+    public class LongSerializer : StringSerializer<long>
+    {
+        /// <inheritdoc/>
+        public override long ParseValue(string value)
+        {
+            return long.Parse(value);
+        }
+
+        /// <inheritdoc/>
+        public override string GetString(long value)
+        {
+            return value.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Native serializer for <see cref="double"/> values.
+    /// </summary>
+    public class DoubleSerializer : StringSerializer<double>
+    {
+        /// <inheritdoc/>
+        public override double ParseValue(string value)
+        {
+            return double.Parse(value);
+        }
+
+        /// <inheritdoc/>
+        public override string GetString(double value)
+        {
+            return value.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Native serializer for <see cref="float"/> values.
+    /// </summary>
+    public class FloatSerializer : StringSerializer<float>
+    {
+        /// <inheritdoc/>
+        public override float ParseValue(string value)
+        {
+            return float.Parse(value);
+        }
+
+        /// <inheritdoc/>
+        public override string GetString(float value)
+        {
+            return value.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Native serializer for <see cref="decimal"/> values.
+    /// </summary>
+    public class DecimalSerializer : StringSerializer<decimal>
+    {
+        /// <inheritdoc/>
+        public override decimal ParseValue(string value)
+        {
+            return decimal.Parse(value);
+        }
+
+        /// <inheritdoc/>
+        public override string GetString(decimal value)
+        {
+            return value.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Native serializer for <see cref="bool"/> values.
+    /// </summary>
+    public class BoolSerializer : StringSerializer<bool>
+    {
+        /// <inheritdoc/>
+        public override bool ParseValue(string value)
+        {
+            return bool.Parse(value);
+        }
+
+        /// <inheritdoc/>
+        public override string GetString(bool value)
+        {
+            return value.ToString();
+        }
+    }
+}

--- a/BassClefStudio.NET.Serialization/CustomTypes/NativeTypes.cs
+++ b/BassClefStudio.NET.Serialization/CustomTypes/NativeTypes.cs
@@ -24,7 +24,14 @@ namespace BassClefStudio.NET.Serialization.CustomTypes
             new VectorSerializer(),
             new DateTimeOffsetSerializer(),
             new DateTimeZoneSerializer(),
-            new DateTimeSpanSerializer()
+            new DateTimeSpanSerializer(),
+            new StringSerializer(),
+            new IntSerializer(),
+            new LongSerializer(),
+            new FloatSerializer(),
+            new DoubleSerializer(),
+            new DecimalSerializer(),
+            new BoolSerializer()
         };
 
         /// <summary>
@@ -40,7 +47,14 @@ namespace BassClefStudio.NET.Serialization.CustomTypes
             typeof(DateTimeOffset),
             typeof(DateTimeZone),
             typeof(Color),
-            typeof(DateTimeSpan)
+            typeof(DateTimeSpan),
+            typeof(string),
+            typeof(int),
+            typeof(long),
+            typeof(float),
+            typeof(double),
+            typeof(decimal),
+            typeof(bool)
         };
 
         /// <summary>

--- a/BassClefStudio.NET.Serialization/Graphs/TypeGroup.cs
+++ b/BassClefStudio.NET.Serialization/Graphs/TypeGroup.cs
@@ -113,7 +113,7 @@ namespace BassClefStudio.NET.Serialization.Graphs
                 return true;
             }
 
-            var trustedTypes = KnownAssemblies.SelectMany(a => a.GetTypes()).Concat(KnownTypes);
+            var trustedTypes = KnownAssemblies.SelectMany(a => a.GetTypes()).Concat(KnownTypes).Distinct();
             if (type.IsGenericType && trustedTypes.Contains(type.GetGenericTypeDefinition()))
             {
                 return true;


### PR DESCRIPTION
This allows for greater control of how these types are serialized, removes the (buggy) code specifying which types would need special JSON serialization, and adds the supported 'native' types to the `NativeTypes` static class.

**Types supported in this release include:**

- `string`
- `int`
- `long`
- `float`
- `double`
- `decimal`
- `bool`

All of these types and their relevant `ICustomSerializer`s have been added to the `NativeTypes` class, which by default includes them in all new `Graph` instances.