### PR TITLE
Added compressed GZipJsonGraphWriter for writing compact string outputs.

### DIFF
--- a/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
+++ b/BassClefStudio.NET.Serialization/BassClefStudio.NET.Serialization.csproj
@@ -5,7 +5,7 @@
     <Authors>BassClefStudio</Authors>
     <Description>A new serialization engine that provides serialization and deserialization services for complex graphs of objects, preserving references and allowing for polymorphism of trusted types, while using JSON as the output format.</Description>
     <RepositoryUrl>https://github.com/bassclefstudio/.NET-Serialization.git</RepositoryUrl>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.NET-Serialization</PackageProjectUrl>
     <PackageId>BassClefStudio.NET.Serialization</PackageId>
     <Product>BassClefStudio.NET.Serialization</Product>

--- a/BassClefStudio.NET.Serialization/GraphInjectionExtensions.cs
+++ b/BassClefStudio.NET.Serialization/GraphInjectionExtensions.cs
@@ -32,14 +32,23 @@ namespace BassClefStudio.NET.Serialization
         /// Registers all default <see cref="IGraphService"/> and <see cref="IGraphWriter"/> services to the DI configuration.
         /// </summary>
         /// <param name="builder">The <see cref="ContainerBuilder"/> DI container.</param>
-        public static void RegisterDefaultGraphServices(this ContainerBuilder builder)
+        /// <param name="useCompression">By default, <see cref="ISerializationService"/> outputs JSON <see cref="string"/>s from the default <see cref="IGraphWriter"/>s. This <see cref="bool"/> determines whether the writer using GZip compression should be used instead of plain text.</param>
+        public static void RegisterDefaultGraphServices(this ContainerBuilder builder, bool useCompression = false)
         {
             builder.RegisterAssemblyTypes(typeof(GraphSerializer).Assembly)
                 .AssignableTo<IGraphService>()
                 .AsImplementedInterfaces();
-            builder.RegisterAssemblyTypes(typeof(GraphSerializer).Assembly)
-                .AssignableTo<IGraphWriter>()
-                .AsImplementedInterfaces();
+
+            if (useCompression)
+            {
+                builder.RegisterType<GZipJsonGraphWriter>()
+                    .AsImplementedInterfaces();
+            }
+            else
+            {
+                builder.RegisterType<JsonGraphWriter>()
+                    .AsImplementedInterfaces();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Adds a new `IGraphWriter` and adjusts the DI extension methods accordingly (added optional parameter). Closes #25.